### PR TITLE
Queues duplication

### DIFF
--- a/queues_flag.go
+++ b/queues_flag.go
@@ -15,6 +15,7 @@ var (
 type queuesFlag []string
 
 func (q *queuesFlag) Set(value string) error {
+	*q = queuesFlag{}
 	for _, queueAndWeight := range strings.Split(value, ",") {
 		if queueAndWeight == "" {
 			continue

--- a/queues_flag_test.go
+++ b/queues_flag_test.go
@@ -79,8 +79,8 @@ var queuesFlagSetTests = []struct {
 }
 
 func TestQueuesFlagSet(t *testing.T) {
+	actual := new(queuesFlag)
 	for _, tt := range queuesFlagSetTests {
-		actual := new(queuesFlag)
 		err := actual.Set(tt.v)
 		if fmt.Sprint(actual) != fmt.Sprint(tt.expected) {
 			t.Errorf("QueuesFlag: set to %s expected %v, actual %v", tt.v, tt.expected, actual)

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,6 +1,7 @@
 package goworker
 
 import (
+	"flag"
 	"reflect"
 	"testing"
 )
@@ -51,9 +52,10 @@ func TestEnqueue(t *testing.T) {
 		},
 	}
 
-	workerSettings.Queues = []string{queueName}
-	workerSettings.UseNumber = true
-	workerSettings.ExitOnComplete = true
+	flag.Set("exit-on-complete", "true")
+	flag.Set("queues", queueName)
+	flag.Set("concurrency", "1")
+	flag.Set("use-number", "true")
 
 	err := Enqueue(expectedJob)
 	if err != nil {


### PR DESCRIPTION
Copying from [original PR](https://github.com/benmanns/goworker/pull/56):

Queue names were duplicating from call to call of Work/Init. Because of that, it duplicated the queues without reason.

Changed in tests to use flags, since it uses them anyway, and as a side effect wipes queue names in case of empty flags.