### PR TITLE
Remove settings ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ func init() {
 		URI:            "redis://localhost:6379/",
 		Connections:    100,
 		// note that -queues flag is still required!
+		// the setting takes precedence though.
 		QueuesString:   "myqueue,delimited,queues",
 		UseNumber:      true,
 		ExitOnComplete: false,

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ func init() {
 	settings := goworker.WorkerSettings{
 		URI:            "redis://localhost:6379/",
 		Connections:    100,
-		Queues:         []string{"myqueue", "delimited", "queues"},
+		QueuesString:   "myqueue,delimited,queues",
 		UseNumber:      true,
 		ExitOnComplete: false,
 		Concurrency:    2,

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ func init() {
 	settings := goworker.WorkerSettings{
 		URI:            "redis://localhost:6379/",
 		Connections:    100,
+		// note that -queues flag is still required!
 		QueuesString:   "myqueue,delimited,queues",
 		UseNumber:      true,
 		ExitOnComplete: false,

--- a/flags.go
+++ b/flags.go
@@ -134,10 +134,10 @@ func flags() error {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
-	if err := workerSettings.Queues.Set(workerSettings.QueuesString); err != nil {
+	if err := workerSettings.queues.Set(workerSettings.QueuesString); err != nil {
 		return err
 	}
-	if err := workerSettings.Interval.SetFloat(workerSettings.IntervalFloat); err != nil {
+	if err := workerSettings.interval.SetFloat(workerSettings.IntervalFloat); err != nil {
 		return err
 	}
 	workerSettings.IsStrict = strings.IndexRune(workerSettings.QueuesString, '=') == -1

--- a/goworker.go
+++ b/goworker.go
@@ -27,9 +27,9 @@ var workerSettings WorkerSettings
 
 type WorkerSettings struct {
 	QueuesString   string
-	Queues         queuesFlag
+	queues         queuesFlag
 	IntervalFloat  float64
-	Interval       intervalFlag
+	interval       intervalFlag
 	Concurrency    int
 	Connections    int
 	URI            string
@@ -142,11 +142,11 @@ func Work() error {
 
 	quit := Signals()
 
-	poller, err := newPoller(workerSettings.Queues, workerSettings.IsStrict)
+	poller, err := newPoller(workerSettings.queues, workerSettings.IsStrict)
 	if err != nil {
 		return err // it will be error only if os.Hostname() fails
 	}
-	jobs, err := poller.poll(time.Duration(workerSettings.Interval), quit)
+	jobs, err := poller.poll(time.Duration(workerSettings.interval), quit)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func Work() error {
 	var monitor sync.WaitGroup
 
 	for id := 0; id < workerSettings.Concurrency; id++ {
-		worker, err := newWorker(strconv.Itoa(id), workerSettings.Queues)
+		worker, err := newWorker(strconv.Itoa(id), workerSettings.queues)
 		if err != nil {
 			return err // it will be error only if os.Hostname() fails
 		}


### PR DESCRIPTION
Example in the README uses SetSettings call with settings Queues and Interval; in fact, this is wrong. Their values would be ignored and overwritten during worker start. QueuesString and IntervalFloat should be used.  
I updated the README and made problematic setting names private.