### PR TITLE
Better use of context

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is a fork of a [bennmans' library goworker](https://github.com/benmanns/gow
 - [xescugs again #1](https://github.com/cycloidio/goworker/pull/4) - kudos to him for contacting me about these additional fixes
 - [xescugs again #2](https://github.com/cycloidio/goworker/pull/8) to prune all workers not mentioned in a heartbeat list
 - [here](https://github.com/skaurus/goworker/pull/17) I added an option to pass a ready Redis client to the lib. If it is not an go-redis v9 instance, you have no guarantees of this working as expected.
+- [and here](https://github.com/skaurus/goworker/pull/17) I added an option to pass a context.Context to the lib. By default it will create context.Background(). This context is used in all Redis methods.
 
 Also [this PR](https://github.com/cycloidio/goworker/pull/9) might be of interest for some, but I did not merged it.
 

--- a/goworker.go
+++ b/goworker.go
@@ -35,6 +35,7 @@ type WorkerSettings struct {
 	URI            string
 	Redis          *redis.Client
 	Namespace      string
+	Ctx            context.Context
 	ExitOnComplete bool
 	IsStrict       bool
 	UseNumber      bool
@@ -69,7 +70,12 @@ func Init() error {
 		if err := flags(); err != nil {
 			return err
 		}
-		ctx = context.Background()
+
+		if workerSettings.Ctx != nil {
+			ctx = workerSettings.Ctx
+		} else {
+			ctx = context.Background()
+		}
 
 		if workerSettings.Redis != nil {
 			// maybe we want to do `*client = *workerSettings.Redis` instead?

--- a/process.go
+++ b/process.go
@@ -1,7 +1,6 @@
 package goworker
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -37,23 +36,23 @@ func (p *process) String() string {
 }
 
 func (p *process) open(c *redis.Client) error {
-	err := c.SAdd(context.Background(), fmt.Sprintf("%sworkers", workerSettings.Namespace), p.String()).Err()
+	err := c.SAdd(ctx, fmt.Sprintf("%sworkers", workerSettings.Namespace), p.String()).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Set(context.Background(), fmt.Sprintf("%sstat:processed:%v", workerSettings.Namespace, p), "0", 0).Err()
+	err = c.Set(ctx, fmt.Sprintf("%sstat:processed:%v", workerSettings.Namespace, p), "0", 0).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Set(context.Background(), fmt.Sprintf("%sstat:failed:%v", workerSettings.Namespace, p), "0", 0).Err()
+	err = c.Set(ctx, fmt.Sprintf("%sstat:failed:%v", workerSettings.Namespace, p), "0", 0).Err()
 	if err != nil {
 		return err
 	}
 
 	// We set the heartbeat as the first thing
-	err = c.HSet(context.Background(), fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String(), time.Now().Format(time.RFC3339)).Err()
+	err = c.HSet(ctx, fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String(), time.Now().Format(time.RFC3339)).Err()
 	if err != nil {
 		return err
 	}
@@ -63,22 +62,22 @@ func (p *process) open(c *redis.Client) error {
 
 func (p *process) close(c *redis.Client) error {
 	logger.Infof("%v shutdown", p)
-	err := c.SRem(context.Background(), fmt.Sprintf("%sworkers", workerSettings.Namespace), p.String()).Err()
+	err := c.SRem(ctx, fmt.Sprintf("%sworkers", workerSettings.Namespace), p.String()).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Del(context.Background(), fmt.Sprintf("%sstat:processed:%s", workerSettings.Namespace, p)).Err()
+	err = c.Del(ctx, fmt.Sprintf("%sstat:processed:%s", workerSettings.Namespace, p)).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Del(context.Background(), fmt.Sprintf("%sstat:failed:%s", workerSettings.Namespace, p)).Err()
+	err = c.Del(ctx, fmt.Sprintf("%sstat:failed:%s", workerSettings.Namespace, p)).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.HDel(context.Background(), fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String()).Err()
+	err = c.HDel(ctx, fmt.Sprintf("%s%s", workerSettings.Namespace, heartbeatKey), p.String()).Err()
 	if err != nil {
 		return err
 	}
@@ -87,7 +86,7 @@ func (p *process) close(c *redis.Client) error {
 }
 
 func (p *process) start(c *redis.Client) error {
-	err := c.Set(context.Background(), fmt.Sprintf("%sworker:%s:started", workerSettings.Namespace, p), time.Now().String(), 0).Err()
+	err := c.Set(ctx, fmt.Sprintf("%sworker:%s:started", workerSettings.Namespace, p), time.Now().String(), 0).Err()
 	if err != nil {
 		return err
 	}
@@ -96,12 +95,12 @@ func (p *process) start(c *redis.Client) error {
 }
 
 func (p *process) finish(c *redis.Client) error {
-	err := c.Del(context.Background(), fmt.Sprintf("%sworker:%s", workerSettings.Namespace, p)).Err()
+	err := c.Del(ctx, fmt.Sprintf("%sworker:%s", workerSettings.Namespace, p)).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Del(context.Background(), fmt.Sprintf("%sworker:%s:started", workerSettings.Namespace, p)).Err()
+	err = c.Del(ctx, fmt.Sprintf("%sworker:%s:started", workerSettings.Namespace, p)).Err()
 	if err != nil {
 		return err
 	}
@@ -110,12 +109,12 @@ func (p *process) finish(c *redis.Client) error {
 }
 
 func (p *process) fail(c *redis.Client) error {
-	err := c.Incr(context.Background(), fmt.Sprintf("%sstat:failed", workerSettings.Namespace)).Err()
+	err := c.Incr(ctx, fmt.Sprintf("%sstat:failed", workerSettings.Namespace)).Err()
 	if err != nil {
 		return err
 	}
 
-	err = c.Incr(context.Background(), fmt.Sprintf("%sstat:failed:%s", workerSettings.Namespace, p)).Err()
+	err = c.Incr(ctx, fmt.Sprintf("%sstat:failed:%s", workerSettings.Namespace, p)).Err()
 	if err != nil {
 		return err
 	}

--- a/workers.go
+++ b/workers.go
@@ -1,7 +1,6 @@
 package goworker
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -34,13 +33,13 @@ func Enqueue(job *Job) error {
 		return err
 	}
 
-	err = client.RPush(context.Background(), fmt.Sprintf("%squeue:%s", workerSettings.Namespace, job.Queue), buffer).Err()
+	err = client.RPush(ctx, fmt.Sprintf("%squeue:%s", workerSettings.Namespace, job.Queue), buffer).Err()
 	if err != nil {
 		_ = logger.Criticalf("Cant push to queue")
 		return err
 	}
 
-	err = client.SAdd(context.Background(), fmt.Sprintf("%squeues", workerSettings.Namespace), job.Queue).Err()
+	err = client.SAdd(ctx, fmt.Sprintf("%squeues", workerSettings.Namespace), job.Queue).Err()
 	if err != nil {
 		_ = logger.Criticalf("Cant register queue to list of use queues")
 		return err


### PR DESCRIPTION
- an option to pass a ready ctx
- using the same ctx everyhere instead of creating new ones

Overall I wanted to have a single context that can be cancelled. I'm not sure yet why I would need it, but these changes seem logical and idiomatic.