### PR TITLE
feat: log worker errors

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -173,6 +173,8 @@ func (w *worker) pruneDeadWorkers(c *redis.Client) {
 }
 
 func (w *worker) fail(c *redis.Client, job *Job, err error) error {
+	_ = logger.Errorf("job failed with %+v; payload was\n%s", err, job.Payload)
+
 	failure := &failure{
 		FailedAt:  time.Now(),
 		Payload:   job.Payload,


### PR DESCRIPTION
Errors were already put to the failed queue, but I would rather prefer to see errors in the log too.