### PR TITLE
Ability to custom-decode tasks from queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a fork of a [bennmans' library goworker](https://github.com/benmanns/gow
 - [and here](https://github.com/skaurus/goworker/pull/17) I added an option to pass a context.Context to the lib. By default it will create a new one via context.Background(). This context is used in all Redis calls.
 - [and here](https://github.com/skaurus/goworker/pull/20) I replaced LPOP + sleep with a BLPOP
 - [and here](https://github.com/skaurus/goworker/pull/21) I started logging worker errors to log
+- [and here](https://github.com/skaurus/goworker/pull/22) I added a RegisterDecoder method, so that your custom types, which were encoded to JSON as payload args, could be decoded to same custom types instead of generic `map[string]interface{}`
 
 Also [this PR](https://github.com/cycloidio/goworker/pull/9) might be of interest for some, but I did not merge it.
 

--- a/worker_func.go
+++ b/worker_func.go
@@ -1,3 +1,5 @@
 package goworker
 
-type workerFunc func(string, ...interface{}) error
+type workerFunc func(queue string, tasks ...interface{}) error
+
+type decoderFunc func(job string) (class string, args []interface{}, err error)

--- a/worker_func.go
+++ b/worker_func.go
@@ -2,4 +2,4 @@ package goworker
 
 type workerFunc func(queue string, tasks ...interface{}) error
 
-type decoderFunc func(job string) (class string, args []interface{}, err error)
+type decoderFunc func(job string) (class string, args interface{}, err error)

--- a/workers.go
+++ b/workers.go
@@ -22,7 +22,7 @@ func Register(class string, worker workerFunc) {
 	workers[class] = worker
 }
 
-func RegisterDecoder(decoder func(job string) (class string, args []interface{}, err error)) {
+func RegisterDecoder(decoder decoderFunc) {
 	customDecoder = decoder
 }
 

--- a/workers.go
+++ b/workers.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	workers map[string]workerFunc
+	workers       map[string]workerFunc
+	customDecoder decoderFunc
 )
 
 func init() {
@@ -19,6 +20,10 @@ func init() {
 // arbitrary array of interfaces as arguments.
 func Register(class string, worker workerFunc) {
 	workers[class] = worker
+}
+
+func RegisterDecoder(decoder func(job string) (class string, args []interface{}, err error)) {
+	customDecoder = decoder
 }
 
 func Enqueue(job *Job) error {


### PR DESCRIPTION
When I started to use goworker, I realized that if I push to queue, as a task argument, some user-defined type, it would be marshalled to json without problem; but when goworker unmarshals it back, it would not unmarshal it to my custom type.
goworker knows nothing about my custom type, so this is not surprising.
For example, this would leave us with `map[string]interface{}` instead of user-defined struct type.

I did not find a good way to cast it to right type. Marshalling it again, and unmarshalling to right type - would work, but it is too ugly. This library [mitchellh/mapstructure](https://github.com/mitchellh/mapstructure) almost did the trick, but chocked on fields with types `time.Time` and `decimal.Decimal`.

So, I introduce the ability to do payload unmarshalling outside of goworker, in the client code.

This required some reflection, unfortunately - I needed a function signature for custom decoder that can output slices of any type to be used as `[]Args`. But the only way to return "any type" is to have return signature of `interface{}`. So some amount of trickery is needed to convert returned slice from interface to slice of interfaces.
And then worker code can cast these interfaces to the final type.