### PR TITLE
Make `logger` configurable

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -42,6 +42,7 @@ type WorkerSettings struct {
 	SkipTLSVerify  bool
 	TLSCertPath    string
 	ForcePrune     bool
+	Logger         seelog.LoggerInterface
 }
 
 func SetSettings(settings WorkerSettings) {
@@ -62,9 +63,13 @@ func Init() error {
 	defer initMutex.Unlock()
 	if !initialized {
 		var err error
-		logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
-		if err != nil {
-			return err
+		if workerSettings.Logger != nil {
+			logger = workerSettings.Logger
+		} else {
+			logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
+			if err != nil {
+				return err
+			}
 		}
 
 		if err := flags(); err != nil {


### PR DESCRIPTION
## Background
Hi! @skaurus 

I came here looking for an asynchronous processing Golang library.  I usually use Rails + Resque, so [benmanns/goworker](https://github.com/benmanns/goworker) looked good, but development had stopped.

skaurus/goworker has been improved from the original, and the dependent libraries have been maintained, so I would definitely like to use it. 

I would like to help with maintenance and further improvements, so I decided to submit a small pull request to try it out.

## Summary
Allow users to use custom logger. Possible reasons are as follows.

- Change log level
  - Some developers want to output debug log
  - In production, output only error logs
- Use logger which filters sensitive parameters